### PR TITLE
mb_strimwidth を利用して23文字に丸めるように変更

### DIFF
--- a/app/Http/Controllers/CardsController.php
+++ b/app/Http/Controllers/CardsController.php
@@ -113,17 +113,9 @@ class CardsController extends Controller
             
             $twitter = new TwitterOAuth($twitter_api_key, $twitter_api_secret_key, $twitter_access_token, $twitter_access_token_secret);
             
-            if (mb_strlen($english) > 20){
-                $short_english = mb_substr($english, 0, 20) . "...";//23
-            } else {
-                $short_english = $english;
-            };
-            
-            if (mb_strlen($japanese) > 20){
-                $short_japanese = mb_substr($japanese, 0, 20) . "…";//23
-            } else {
-                $short_japanese = $japanese;
-            };
+
+            $short_english  = mb_strimwidth($english, 0, 23, "...");
+            $short_japanese = mb_strimwidth($japanese, 0, 23, "...");
 
             $twitter->post("statuses/update", [
                 "status" =>


### PR DESCRIPTION
別途関数を下記のように作成しても良いと思います。

```
function xxx($longStr) {
    $maxLength = 20;
    $trimmarker = "...";
    return mb_strimwidth($longStr, 0, mb_strlen($trimmarker) + $maxLength, $trimmarker);
}
```

ちなみにTwitterへの送信関連（TwitterOAuthの初期化〜post）は別のクラスで処理させるべきだと思いまし、

>                     'http://my-dictionary2019.herokuapp.com/'

こちらも固定文字列で行うのではなく、実行中のサーバ環境を取得するか、環境変数で持つのが望ましいと思います。